### PR TITLE
When archiving tasks, return to the first line where tasks were removed.

### DIFF
--- a/ftplugin/tada.vim
+++ b/ftplugin/tada.vim
@@ -70,7 +70,7 @@ function! s:Archive() range
   let range_length = a:lastline - a:firstline + 1
 
   execute a:firstline . ',' . a:lastline . 's/^/= /'
-  execute a:firstline . ',' . a:lastline . 'm$'
+  silent execute a:firstline . ',' . a:lastline . 'm$'
 
   let previous_num = line('$') - range_length
 

--- a/ftplugin/tada.vim
+++ b/ftplugin/tada.vim
@@ -77,6 +77,9 @@ function! s:Archive() range
   if getline(previous_num) !~ '^='
     call append(previous_num, ['', '==='])
   endif
+
+  " return to the last cursor position before tasks were removed
+  execute a:firstline
 endfunction
 command -nargs=0 -range TadaArchive :<line1>,<line2>call <SID>Archive()
 


### PR DESCRIPTION
Archiving tasks leaves the cursor in the archive area. This PR puts the cursor back to where the tasks were removed from.