### PR TITLE
Add syntax highlighting for project, context like todo.txt

### DIFF
--- a/syntax/tada.vim
+++ b/syntax/tada.vim
@@ -14,7 +14,7 @@ syn case ignore
 execute 'syn match tadaDescription "' . g:tada_pat_description . '"'
 execute 'syn match tadaArchive "' . g:tada_pat_archive . '"'
 execute 'syn match tadaComment "' . g:tada_pat_comment . '"'
-execute 'syn match tadaListItem "' . g:tada_pat_list_item . '"'
+execute 'syn match tadaListItem "' . g:tada_pat_list_item . '" contains=tadaContext,tadaProject'
 execute 'syn match tadaListItem "' . g:tada_pat_list_item_empty . '"'
 execute 'syn match tadaMetadata "' . g:tada_pat_metadata . '"'
 execute 'syn match tadaNote "' . g:tada_pat_note . '"'
@@ -27,11 +27,14 @@ endfor
 for [status, symbol] in items(b:tada_todo_symbols)
   let name = tada#utils#Camelize(status)
 
-  execute 'syn match tadaTodoItem' . name . ' /^\s*-\s*\[' . symbol . '\].*$/'
+  execute 'syn match tadaTodoItem' . name . ' /^\s*-\s*\[' . symbol . '\].*$/ contains=tadaContext,tadaProject'
 endfor
 
 execute 'syn match tadaInvalidConfig "' . g:tada_pat_invalid_config . '"'
 execute 'syn match tadaBufferConfig "' . g:tada_pat_buffer_config . '"'
+
+syn match tadaContext '\(^\|\W\)@[^[:blank:]]\+'
+syn match tadaProject '\(^\|\W\)+[^[:blank:]]\+'
 
 hi def link tadaArchive Comment
 hi def link tadaBufferConfig Comment
@@ -48,6 +51,9 @@ hi def link tadaTopicTitle3 String
 hi def link tadaTopicTitle4 Define
 hi def link tadaTopicTitle5 Function
 hi def link tadaTopicTitle6 String
+
+hi def link tadaContext Special
+hi def link tadaProject Special
 
 hi Folded guifg=CadetBlue
 


### PR DESCRIPTION
Not sure if this aligns with your project vision, but wanted to share. [todo.txt is a single-line todo format](https://github.com/todotxt/todo.txt) that has some nice elements for marking context (e.g., @work, @email) and project (+vim-tada, +workproj). Adding this syntax highlighting makes my vim-tada lists more scannable. It does seem a bit duplicative to `#:tags` in the metadata though.